### PR TITLE
Add run to Action class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 #### New Features
  - Added bash scripts and dockerfile to allow for deploying using Docker
 
+#### Misc
+ - Remove take_action from Change and put logic in Action method run()
+
 ## Release 1.0.4
 
 #### New Features

--- a/src/python/autotransform/change/base.py
+++ b/src/python/autotransform/change/base.py
@@ -16,15 +16,6 @@ from enum import Enum
 from typing import TYPE_CHECKING, ClassVar, List
 
 from autotransform.batcher.base import Batch
-from autotransform.step.action.base import Action
-from autotransform.step.action.comments import CommentAction
-from autotransform.step.action.labels import AddLabelsAction, RemoveLabelAction
-from autotransform.step.action.reviewers import (
-    AddOwnersAsReviewersAction,
-    AddOwnersAsTeamReviewersAction,
-    AddReviewersAction,
-)
-from autotransform.step.action.source import AbandonAction, MergeAction, NoneAction, UpdateAction
 from autotransform.util.component import ComponentFactory, ComponentImport, NamedComponent
 
 if TYPE_CHECKING:
@@ -130,53 +121,8 @@ class Change(NamedComponent):
             int: The timestamp in seconds when the Change was last updated.
         """
 
-    # pylint: disable=too-many-return-statements
-    def take_action(self, action: Action, runner: Runner) -> bool:
-        """Tells the Change to take an Action based on the results of a Step run.
-
-        Args:
-            action (Action): The Action to take.
-            runner (Runner): A Runner which can be used to take an Action.
-
-        Returns:
-            bool: Whether the Action was taken successfully.
-        """
-
-        if isinstance(action, AbandonAction):
-            return self._abandon()
-
-        if isinstance(action, AddLabelsAction):
-            return self._add_labels(action.labels)
-
-        if isinstance(action, AddOwnersAsReviewersAction):
-            return self._add_reviewers(self.get_schema().config.owners, [])
-
-        if isinstance(action, AddOwnersAsTeamReviewersAction):
-            return self._add_reviewers([], self.get_schema().config.owners)
-
-        if isinstance(action, AddReviewersAction):
-            return self._add_reviewers(action.reviewers, action.team_reviewers)
-
-        if isinstance(action, CommentAction):
-            return self._comment(action.body)
-
-        if isinstance(action, MergeAction):
-            return self._merge()
-
-        if isinstance(action, NoneAction):
-            return True
-
-        if isinstance(action, RemoveLabelAction):
-            return self._remove_label(action.label)
-
-        if isinstance(action, UpdateAction):
-            return self._update(runner)
-
-        # No known way to handle the Action, so treat it as failed
-        return False
-
     @abstractmethod
-    def _abandon(self) -> bool:
+    def abandon(self) -> bool:
         """Close out and abandon a Change, removing it from the code review
         and/or version control system.
 
@@ -185,7 +131,7 @@ class Change(NamedComponent):
         """
 
     @abstractmethod
-    def _add_labels(self, labels: List[str]) -> bool:
+    def add_labels(self, labels: List[str]) -> bool:
         """Adds labels to an outstanding Change.
 
         Args:
@@ -196,7 +142,7 @@ class Change(NamedComponent):
         """
 
     @abstractmethod
-    def _add_reviewers(self, reviewers: List[str], team_reviewers: List[str]) -> bool:
+    def add_reviewers(self, reviewers: List[str], team_reviewers: List[str]) -> bool:
         """Adds reviewers to an outstanding Change.
 
         Args:
@@ -208,7 +154,7 @@ class Change(NamedComponent):
         """
 
     @abstractmethod
-    def _comment(self, body: str) -> bool:
+    def comment(self, body: str) -> bool:
         """Comments on an outstanding Change.
 
         Args:
@@ -219,7 +165,7 @@ class Change(NamedComponent):
         """
 
     @abstractmethod
-    def _merge(self) -> bool:
+    def merge(self) -> bool:
         """Merges an approved change in to main.
 
         Returns:
@@ -227,7 +173,7 @@ class Change(NamedComponent):
         """
 
     @abstractmethod
-    def _remove_label(self, label: str) -> bool:
+    def remove_label(self, label: str) -> bool:
         """Removes a label from an outstanding Change.
 
         Args:
@@ -237,7 +183,7 @@ class Change(NamedComponent):
             bool: Whether the label was removed successfully.
         """
 
-    def _update(self, runner: Runner) -> bool:
+    def update(self, runner: Runner) -> bool:
         """Update an outstanding Change against the latest state of the codebase.
 
         Args:

--- a/src/python/autotransform/change/github.py
+++ b/src/python/autotransform/change/github.py
@@ -153,7 +153,7 @@ class GithubChange(Change):
 
         return self._pull_request.get_updated_at()
 
-    def _abandon(self) -> bool:
+    def abandon(self) -> bool:
         """Close the Pull Request and delete the associated branch.
 
         Returns:
@@ -164,7 +164,7 @@ class GithubChange(Change):
             return False
         return self._pull_request.delete_branch()
 
-    def _add_labels(self, labels: List[str]) -> bool:
+    def add_labels(self, labels: List[str]) -> bool:
         """Adds labels to an outstanding Change.
 
         Args:
@@ -177,7 +177,7 @@ class GithubChange(Change):
         self._pull_request.add_labels(labels)
         return True
 
-    def _add_reviewers(self, reviewers: List[str], team_reviewers: List[str]) -> bool:
+    def add_reviewers(self, reviewers: List[str], team_reviewers: List[str]) -> bool:
         """Adds reviewers to an outstanding Change.
 
         Args:
@@ -191,7 +191,7 @@ class GithubChange(Change):
         self._pull_request.add_reviewers(reviewers, team_reviewers)
         return True
 
-    def _comment(self, body: str) -> bool:
+    def comment(self, body: str) -> bool:
         """Comments on an outstanding Change.
 
         Args:
@@ -204,7 +204,7 @@ class GithubChange(Change):
         self._pull_request.create_comment(body)
         return True
 
-    def _merge(self) -> bool:
+    def merge(self) -> bool:
         """Merges the Pull Request and deletes the branch.
 
         Returns:
@@ -215,7 +215,7 @@ class GithubChange(Change):
             return False
         return self._pull_request.delete_branch()
 
-    def _remove_label(self, label: str) -> bool:
+    def remove_label(self, label: str) -> bool:
         """Removes a label from an outstanding Change.
 
         Args:

--- a/src/python/autotransform/schema/schema.py
+++ b/src/python/autotransform/schema/schema.py
@@ -201,8 +201,7 @@ class AutoTransformSchema(ComponentModel):
                         DebugEvent({"message": "No changes in update, abandoning"})
                     )
 
-                    # pylint: disable=protected-access
-                    change._abandon()
+                    change.abandon()
                 event_handler.handle(DebugEvent({"message": "No changes found"}))
         event_handler.handle(DebugEvent({"message": "Finish batch"}))
         autotransform.schema.current = None

--- a/src/python/autotransform/step/action/base.py
+++ b/src/python/autotransform/step/action/base.py
@@ -9,9 +9,11 @@
 
 """The base class and associated classes for Action components."""
 
+from abc import abstractmethod
 from enum import Enum
 from typing import ClassVar
 
+from autotransform.change.base import Change
 from autotransform.util.component import ComponentFactory, ComponentImport, NamedComponent
 
 
@@ -40,6 +42,17 @@ class Action(NamedComponent):
     """
 
     name: ClassVar[ActionName]
+
+    @abstractmethod
+    def run(self, change: Change) -> bool:
+        """Performs the action on the specified Change.
+
+        Args:
+            change (Change): The Change to perform the Action on.
+
+        Returns:
+            bool: Whether the Action was successful.
+        """
 
 
 FACTORY = ComponentFactory(

--- a/src/python/autotransform/step/action/comments.py
+++ b/src/python/autotransform/step/action/comments.py
@@ -13,6 +13,7 @@ from typing import ClassVar
 
 from pydantic import validator
 
+from autotransform.change.base import Change
 from autotransform.step.action.base import Action, ActionName
 
 
@@ -47,3 +48,15 @@ class CommentAction(Action):
         if v == "":
             raise ValueError("Comment body must be non-empty")
         return v
+
+    def run(self, change: Change) -> bool:
+        """Adds a comment to the specified Change.
+
+        Args:
+            change (Change): The Change to comment on.
+
+        Returns:
+            bool: Whether the comment was successful.
+        """
+
+        return change.comment(self.body)

--- a/src/python/autotransform/step/action/labels.py
+++ b/src/python/autotransform/step/action/labels.py
@@ -13,6 +13,7 @@ from typing import ClassVar, List
 
 from pydantic import validator
 
+from autotransform.change.base import Change
 from autotransform.step.action.base import Action, ActionName
 
 
@@ -50,6 +51,18 @@ class AddLabelsAction(Action):
             raise ValueError("Labels must be non-empty strings")
         return v
 
+    def run(self, change: Change) -> bool:
+        """Adds labels to the specified Change.
+
+        Args:
+            change (Change): The Change to add labels to.
+
+        Returns:
+            bool: Whether the labels were added successful.
+        """
+
+        return change.add_labels(self.labels)
+
 
 class RemoveLabelAction(Action):
     """Removes a label from an existing Change.
@@ -82,3 +95,15 @@ class RemoveLabelAction(Action):
         if v == "":
             raise ValueError("Label to remove must be non-empty")
         return v
+
+    def run(self, change: Change) -> bool:
+        """Removes labels from the specified Change.
+
+        Args:
+            change (Change): The Change to remove labels from.
+
+        Returns:
+            bool: Whether the labels were removed successful.
+        """
+
+        return change.remove_label(self.label)

--- a/src/python/autotransform/step/action/reviewers.py
+++ b/src/python/autotransform/step/action/reviewers.py
@@ -13,6 +13,7 @@ from typing import Any, ClassVar, Dict, List
 
 from pydantic import Field, root_validator, validator
 
+from autotransform.change.base import Change
 from autotransform.step.action.base import Action, ActionName
 
 
@@ -90,6 +91,18 @@ class AddReviewersAction(Action):
             raise ValueError("Either reviewers or team reviewers must be supplied")
         return values
 
+    def run(self, change: Change) -> bool:
+        """Adds reviewers to the specified Change.
+
+        Args:
+            change (Change): The Change to add reviewers to.
+
+        Returns:
+            bool: Whether the reviewers were added successful.
+        """
+
+        return change.add_reviewers(self.reviewers, self.team_reviewers)
+
 
 class AddOwnersAsReviewersAction(Action):
     """Adds the owners of a Schema as reviewers for the Change.
@@ -100,6 +113,18 @@ class AddOwnersAsReviewersAction(Action):
 
     name: ClassVar[ActionName] = ActionName.ADD_OWNERS_AS_REVIEWERS
 
+    def run(self, change: Change) -> bool:
+        """Adds owners as reviewers to the specified Change.
+
+        Args:
+            change (Change): The Change to add reviewers to.
+
+        Returns:
+            bool: Whether the reviewers were added successful.
+        """
+
+        return change.add_reviewers(change.get_schema().config.owners, [])
+
 
 class AddOwnersAsTeamReviewersAction(Action):
     """Adds the owners of a Schema as team reviewers for the Change.
@@ -109,3 +134,15 @@ class AddOwnersAsTeamReviewersAction(Action):
     """
 
     name: ClassVar[ActionName] = ActionName.ADD_OWNERS_AS_TEAM_REVIEWERS
+
+    def run(self, change: Change) -> bool:
+        """Adds owners as team reviewers to the specified Change.
+
+        Args:
+            change (Change): The Change to add team reviewers to.
+
+        Returns:
+            bool: Whether the team reviewers were added successful.
+        """
+
+        return change.add_reviewers([], change.get_schema().config.owners)

--- a/src/python/autotransform/step/action/source.py
+++ b/src/python/autotransform/step/action/source.py
@@ -9,8 +9,12 @@
 
 """All Actions associated with handling source control options for a Change."""
 
+from functools import cached_property
 from typing import ClassVar
 
+from autotransform.change.base import Change
+from autotransform.config import get_config
+from autotransform.runner.base import Runner
 from autotransform.step.action.base import Action, ActionName
 
 
@@ -23,6 +27,18 @@ class AbandonAction(Action):
 
     name: ClassVar[ActionName] = ActionName.ABANDON
 
+    def run(self, change: Change) -> bool:
+        """Abandons a specified Change.
+
+        Args:
+            change (Change): The Change to abandon.
+
+        Returns:
+            bool: Whether the Change was abandoned successfully.
+        """
+
+        return change.abandon()
+
 
 class MergeAction(Action):
     """Merges an outstanding Change.
@@ -32,6 +48,18 @@ class MergeAction(Action):
     """
 
     name: ClassVar[ActionName] = ActionName.MERGE
+
+    def run(self, change: Change) -> bool:
+        """Merges a specified Change.
+
+        Args:
+            change (Change): The Change to merge.
+
+        Returns:
+            bool: Whether the Change was merged successfully.
+        """
+
+        return change.merge()
 
 
 class NoneAction(Action):
@@ -43,12 +71,52 @@ class NoneAction(Action):
 
     name: ClassVar[ActionName] = ActionName.NONE
 
+    def run(self, change: Change) -> bool:
+        """Performs no action.
+
+        Args:
+            change (Change): The Change to having no action taken on it
+
+        Returns:
+            bool: Always returns True.
+        """
+
+        return True
+
 
 class UpdateAction(Action):
     """Updates an outstanding Change.
 
     Attributes:
+        use_local_runner(optional, bool): Whether to use the local runner. Defaults to False.
         name (ClassVar[ActionName]): The name of the component.
     """
 
+    use_local_runner: bool = False
+
     name: ClassVar[ActionName] = ActionName.UPDATE
+
+    @cached_property
+    def _runner(self) -> Runner:
+        """A cached Runner from the config.
+
+        Returns:
+            Runner: The Runner to use to update Changes.
+        """
+
+        conf = get_config()
+        runner = conf.local_runner if self.use_local_runner else conf.remote_runner
+        assert runner is not None
+        return runner
+
+    def run(self, change: Change) -> bool:
+        """Updates a specified Change.
+
+        Args:
+            change (Change): The Change to update.
+
+        Returns:
+            bool: Whether the Change was updated successfully.
+        """
+
+        return change.update(self._runner)

--- a/src/python/autotransform/util/manager.py
+++ b/src/python/autotransform/util/manager.py
@@ -67,7 +67,7 @@ class Manager(ComponentModel):
                     EventHandler.get().handle(
                         ManageActionEvent({"action": action, "change": change, "step": step})
                     )
-                    change.take_action(action, self.runner)
+                    action.run(change)
 
                 if actions and not step.continue_management(change):
                     EventHandler.get().handle(DebugEvent({"message": "Steps ended"}))


### PR DESCRIPTION
Gets rid of take_action() which was a massive pile of ifs that could lead to some actions missing from the Change. Now we have Action.run(change). Fixes https://github.com/nathro/AutoTransform/issues/52

This also gets rid of the usage of runner in Manager in preparation for https://github.com/nathro/AutoTransform/issues/53