### PR TITLE
Make it so GithubRunner can trigger workflows from repos other than the one of the schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Release 1.0.5
+## Release 1.0.6
 
 ### Features
  - Support GithubRunner using repos outside the schema's repo to trigger workflows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Release 1.0.5
+
+### Features
+ - Support GithubRunner using repos outside the schema's repo to trigger workflows.
+
 ## Post Release 1.0.5
  - Fixed migration scripts
 

--- a/src/python/autotransform/runner/github.py
+++ b/src/python/autotransform/runner/github.py
@@ -12,7 +12,7 @@
 from __future__ import annotations
 
 import json
-from typing import ClassVar
+from typing import Any, ClassVar, Dict, Optional
 
 from autotransform.change.base import Change
 from autotransform.event.debug import DebugEvent
@@ -33,11 +33,18 @@ class GithubRunner(Runner):
     Attributes:
         run_workflow (str): The name of the workflow to use for running a Schema.
         update_workflow (str): The name of the workflow to use for updating a Change.
+        repo_name (optional, Optional[str]): The name of the Github repo to trigger actions from.
+            If not provided, the repo of the Schema will be used. Defaults to None.
+        repo_ref (optional, Optional[str]): The ref of the Github repo to trigger actions from.
+            If not provided, the base branch of the Schema's repo will be used. Defaults to None.
         name (ClassVar[RunnerName]): The name of the component.
     """
 
     run_workflow: str
     update_workflow: str
+
+    repo_name: Optional[str] = None
+    repo_ref: Optional[str] = None
 
     name: ClassVar[RunnerName] = RunnerName.GITHUB
 
@@ -50,25 +57,19 @@ class GithubRunner(Runner):
         """
 
         event_handler = EventHandler.get()
-        repo = schema.repo
 
-        assert isinstance(
-            repo, GithubRepo
-        ), "GithubRunner can only run using schemas that have Github repos"
-
-        # Dispatch a Workflow run
+        # Set up inputs
         workflow_inputs = {"schema": schema.config.schema_name}
         if schema.config.max_submissions:
             workflow_inputs["max_submissions"] = str(schema.config.max_submissions)
         shard_filter = [filt for filt in schema.filters if isinstance(filt, ShardFilter)]
         if shard_filter:
             workflow_inputs["filter"] = json.dumps(shard_filter[0].bundle())
-        workflow_url = GithubUtils.get(repo.full_github_name).create_workflow_dispatch(
-            self.run_workflow,
-            repo.base_branch,
-            workflow_inputs,
-        )
+
+        # Dispatch a Workflow run
+        workflow_url = self._create_workflow_dispatch(self.run_workflow, schema, workflow_inputs)
         assert workflow_url is not None, "Failed to dispatch workflow request"
+
         event_handler.handle(DebugEvent({"message": "Successfully dispatched workflow run"}))
         if workflow_url == "":
             event_handler.handle(DebugEvent({"message": "No guess for workflow run URL."}))
@@ -94,22 +95,13 @@ class GithubRunner(Runner):
         """
 
         event_handler = EventHandler.get()
-        schema = change.get_schema()
-        repo = schema.repo
-
-        # May add support for cross-repo usage but enforce that the workflow being invoked exists
-        # in the target repo for now
-        assert isinstance(
-            repo, GithubRepo
-        ), "GithubRunner can only update changes using schemas that have Github repos"
 
         # Dispatch a Workflow run
-        workflow_url = GithubUtils.get(repo.full_github_name).create_workflow_dispatch(
-            self.update_workflow,
-            repo.base_branch,
-            {"change": json.dumps(change.bundle())},
+        workflow_url = self._create_workflow_dispatch(
+            self.update_workflow, change.get_schema(), {"change": json.dumps(change.bundle())}
         )
         assert workflow_url is not None, "Failed to dispatch workflow request"
+
         event_handler.handle(DebugEvent({"message": "Successfully dispatched workflow run"}))
         if workflow_url == "":
             event_handler.handle(DebugEvent({"message": "No guess for workflow run URL."}))
@@ -123,3 +115,44 @@ class GithubRunner(Runner):
             )
         )
         event_handler.handle(RemoteUpdateEvent({"change": change, "ref": workflow_url}))
+
+    def _create_workflow_dispatch(
+        self, workflow_name: str, schema: AutoTransformSchema, inputs: Dict[str, Any]
+    ) -> str:
+        """Creates a workflow dispatch
+
+        Args:
+            workflow_name (str): The name of the workflow to dispatch.
+            schema (AutoTransformSchema): The Schema that is involved with the dispatch.
+            inputs (Dict[str, Any]): The inputs for the dispatch.
+
+        Returns:
+            str: The URL for the workflow run.
+        """
+
+        if self.repo_name is not None:
+            repo_name = self.repo_name
+        else:
+            repo = schema.repo
+            assert isinstance(
+                repo, GithubRepo
+            ), "GithubRunner can only run using schemas that have Github repos"
+            repo_name = repo.full_github_name
+
+        if self.repo_ref is not None:
+            repo_ref = self.repo_ref
+        else:
+            repo = schema.repo
+            assert isinstance(
+                repo, GithubRepo
+            ), "GithubRunner can only run using schemas that have Github repos"
+            repo_ref = repo.base_branch
+
+        # Dispatch a Workflow run
+        workflow_url = GithubUtils.get(repo_name).create_workflow_dispatch(
+            workflow_name,
+            repo_ref,
+            inputs,
+        )
+        assert workflow_url is not None, "Failed to dispatch workflow request"
+        return workflow_url


### PR DESCRIPTION
Simple change so you can have your workflows in a different repo from what you're running AutoTransform against.