### PR TITLE
Make GitRepo strip bad substrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
  - Support GithubRunner using repos outside the schema's repo to trigger workflows.
+ - Make GitRepo strip some bad substrings from branch names
 
 ## Post Release 1.0.5
  - Fixed migration scripts

--- a/src/python/autotransform/repo/git.py
+++ b/src/python/autotransform/repo/git.py
@@ -81,7 +81,7 @@ class GitRepo(Repo):
 
         branch_name = f"{GitRepo.BRANCH_NAME_PREFIX}/{schema_name}/{fixed_title}"
         # Replace bad characters
-        substring_replacements = {":": "", "^": "", "~": "", "..": "", " ": "_", "?": "", "*": ""}
+        substring_replacements = {":": "-", "^": "", "~": "", "..": "", " ": "_", "?": "", "*": ""}
         for substr, repl in substring_replacements.items():
             branch_name.replace(substr, repl)
 

--- a/src/python/autotransform/repo/git.py
+++ b/src/python/autotransform/repo/git.py
@@ -79,7 +79,7 @@ class GitRepo(Repo):
         else:
             schema_name = ""
 
-        branch_name = f"{GitRepo.BRANCH_NAME_PREFIX}/{schema_name}/{fixed_title}"
+        branch_name = f"{GitRepo.BRANCH_NAME_PREFIX}/{schema_name}{fixed_title}"
         # Replace bad characters
         substring_replacements = {":": "-", "^": "", "~": "", "..": "", " ": "_", "?": "", "*": ""}
         for substr, repl in substring_replacements.items():

--- a/src/python/autotransform/repo/git.py
+++ b/src/python/autotransform/repo/git.py
@@ -83,7 +83,7 @@ class GitRepo(Repo):
         # Replace bad characters
         substring_replacements = {":": "-", "^": "", "~": "", "..": "", " ": "_", "?": "", "*": ""}
         for substr, repl in substring_replacements.items():
-            branch_name.replace(substr, repl)
+            branch_name = branch_name.replace(substr, repl)
 
         return branch_name
 

--- a/src/python/autotransform/repo/git.py
+++ b/src/python/autotransform/repo/git.py
@@ -73,11 +73,19 @@ class GitRepo(Repo):
 
         # Handle titles of the format "[1/2] foo" that can come from chunk batching
         fixed_title = re.sub(r"\[(\d+)/(\d+)\]", r"\1_\2", title)
+
         if autotransform.schema.current is not None:
             schema_name = f"{autotransform.schema.current.config.schema_name}/"
         else:
             schema_name = ""
-        return f"{GitRepo.BRANCH_NAME_PREFIX}/{schema_name}{fixed_title}".replace(" ", "_")
+
+        branch_name = f"{GitRepo.BRANCH_NAME_PREFIX}/{schema_name}/{fixed_title}"
+        # Replace bad characters
+        substring_replacements = {":": "", "^": "", "~": "", "..": "", " ": "_", "?": "", "*": ""}
+        for substr, repl in substring_replacements.items():
+            branch_name.replace(substr, repl)
+
+        return branch_name
 
     @staticmethod
     def get_commit_message(title: str) -> str:


### PR DESCRIPTION
Makes some tweaks to GitRepo to try to prevent bad branch names from causing problems