### PR TITLE
Make GitGrep no longer include repo dir in file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
  - Support GithubRunner using repos outside the schema's repo to trigger workflows.
  - Make GitRepo strip some bad substrings from branch names
 
+### Fixes
+ - Made the GitGrepInput no longer include repo dir in the name of the file. This is unneeded for accessing the file and causes bad behavior when combined with things that use file names that are run on remote machines
+
 ## Post Release 1.0.5
  - Fixed migration scripts
 

--- a/src/python/autotransform/input/gitgrep.py
+++ b/src/python/autotransform/input/gitgrep.py
@@ -37,8 +37,7 @@ class GitGrepInput(Input):
         Returns:
             Sequence[FileItem]: The eligible files for transformation.
         """
-        dir_cmd = ["git", "rev-parse", "--show-toplevel"]
-        repo_dir = subprocess.check_output(dir_cmd, encoding="UTF-8").replace("\\", "/").strip()
+
         git_grep_cmd = [
             "git",
             "grep",
@@ -47,12 +46,10 @@ class GitGrepInput(Input):
             "--untracked",
             "-e",
             self.pattern,
-            "--",
-            repo_dir,
         ]
 
         try:
             files = subprocess.check_output(git_grep_cmd, encoding="UTF-8").strip().splitlines()
         except subprocess.CalledProcessError:
             return []
-        return [FileItem(key=f"{repo_dir}/" + file.replace("\\", "/")) for file in files]
+        return [FileItem(key=file.replace("\\", "/")) for file in files]

--- a/tests/input/test_gitgrep.py
+++ b/tests/input/test_gitgrep.py
@@ -19,7 +19,7 @@ def test_pattern_present() -> None:
     found_files = inp.get_items()
     assert len(found_files) == 1, "Only one file match expected."
     test_file = __file__.lower().replace("\\", "/")
-    assert found_files[0].get_path().lower() == test_file, "The test file should be found."
+    assert test_file.endswith(found_files[0].get_path().lower()), "The test file should be found."
 
 
 def test_pattern_not_present() -> None:


### PR DESCRIPTION
This was leading to weird behavior with runs on remote machines. Including the repo dir in the filename would make remote runs use arbitrary paths that could show up in branches (i.e. for DirectoryBatcher) and lead to unexpected behavior.