### PR TITLE
Switch from pull list API to search API for getting open pulls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### New Components
  - MergeableStateCondition
+
+### Fixes
+ - Fixed an issue with user config not saving to the right location when using settings command
+ - Fixed an issue where get_open_pull_requests didn't work for GithubRepos with large numbers of open PRs
+
 ## Release 1.0.6
 
 ### New Components

--- a/src/python/autotransform/change/github.py
+++ b/src/python/autotransform/change/github.py
@@ -269,12 +269,12 @@ class GithubChange(Change):
         self._pull_request.remove_label(label)
         return True
 
-    @cached_property
+    @property
     def _pull_request(self) -> PullRequest:
-        """Gets the Pull Request as a cached property.
+        """Gets the Pull Request.
 
         Returns:
-            PullRequest: The PullRequest.
+            PullRequest: The Pull Request.
         """
 
         return GithubUtils.get(self.full_github_name).get_pull_request(self.pull_number)


### PR DESCRIPTION
Using the list API works when you don't have a lot of outstanding PRs, but for a large organization this would be really inefficient, so we switch to the search API instead. This also fixes a bug where we didn't handle paging of results from the API.

Because we're using a different API now, we're also changing how data is gathered from PRs, using the pulls.get API for all data, rather than caching some from the list API, this lets us simplify some things to not recreate objects.