### PR TITLE
Support scaling AutoTransform across many repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Release 1.0.8
+
+### Features
+ - Added an optional repo_override setting to Config that can be used to override the repo of supplied schemas
+ - Added AUTO_TRANSFORM_SCHEMA_MAP_PATH environment variable support to override default schema_map path
+
 ## Release 1.0.7
 
 ### New Components

--- a/docs/source/autotransform.validator.rst
+++ b/docs/source/autotransform.validator.rst
@@ -3,9 +3,6 @@ Validator Package (autotransform.validator)
 
 .. automodule:: autotransform.validator
 
-Components
-----------
-
 .. toctree::
    :maxdepth: 4
 

--- a/src/python/autotransform/change/github.py
+++ b/src/python/autotransform/change/github.py
@@ -17,7 +17,7 @@ from typing import ClassVar, Dict, List, Tuple
 
 from autotransform.batcher.base import Batch
 from autotransform.change.base import Change, ChangeName, ChangeState, ReviewState, TestState
-from autotransform.config import get_repo_config_relative_path
+from autotransform.config import get_config, get_schema_map_path
 from autotransform.item.base import FACTORY as item_factory
 from autotransform.schema.builder import FACTORY as schema_builder_factory
 from autotransform.schema.schema import AutoTransformSchema
@@ -56,8 +56,7 @@ class GithubChange(Change):
         """
 
         schema_name = self.get_schema_name()
-        map_file_path = f"{get_repo_config_relative_path()}/schema_map.json"
-        with open(map_file_path, "r", encoding="UTF-8") as map_file:
+        with open(get_schema_map_path(), "r", encoding="UTF-8") as map_file:
             schema_map = json.loads(map_file.read())
         data = schema_map[schema_name]
         schema_type = SchemaType(data["type"])
@@ -67,6 +66,9 @@ class GithubChange(Change):
             with open(data["target"], "r", encoding="utf-8") as schema_file:
                 schema = AutoTransformSchema.from_data(json.loads(schema_file.read()))
         assert schema_name == schema.config.schema_name
+        repo_override = get_config().repo_override
+        if repo_override is not None:
+            schema.repo = repo_override
 
         return schema
 

--- a/src/python/autotransform/config/__init__.py
+++ b/src/python/autotransform/config/__init__.py
@@ -29,6 +29,19 @@ if TYPE_CHECKING:
 CONFIG_FILE_NAME = "config.json"
 
 
+def get_schema_map_path() -> str:
+    """Gets the path to the schema map.
+
+    Returns:
+        str: The path to the schema map.
+    """
+
+    return os.getenv(
+        "AUTO_TRANSFORM_SCHEMA_MAP_PATH",
+        f"{get_repo_config_relative_path()}/schema_map.json",
+    )
+
+
 def get_repo_config_relative_path() -> str:
     """Gets the relative path used for the repo config directory.
 

--- a/src/python/autotransform/scripts/commands/initialize.py
+++ b/src/python/autotransform/scripts/commands/initialize.py
@@ -20,6 +20,7 @@ from autotransform.config import (
     get_cwd_config_dir,
     get_repo_config_dir,
     get_repo_config_relative_path,
+    get_schema_map_path,
 )
 from autotransform.config.config import Config
 from autotransform.repo.base import RepoName
@@ -260,7 +261,7 @@ def initialize_repo(
         requirements_file.flush()
 
     # Set up schema map file
-    schema_map_path = f"{repo_config_dir}/schema_map.json"
+    schema_map_path = get_schema_map_path()
     os.makedirs(os.path.dirname(schema_map_path), exist_ok=True)
     with open(schema_map_path, "w+", encoding="UTF-8") as schema_map_file:
         schema_map_file.write(json.dumps(schema_map))

--- a/src/python/autotransform/scripts/commands/run.py
+++ b/src/python/autotransform/scripts/commands/run.py
@@ -14,7 +14,7 @@ import json
 import os
 from argparse import ArgumentParser, Namespace
 
-from autotransform.config import get_config, get_repo_config_relative_path
+from autotransform.config import get_config, get_schema_map_path
 from autotransform.event.debug import DebugEvent
 from autotransform.event.handler import EventHandler
 from autotransform.event.logginglevel import LoggingLevel
@@ -165,8 +165,7 @@ def run_command_main(args: Namespace) -> None:
         assert isinstance(schema, str)
         schema = AutoTransformSchema.from_data(json.loads(schema))
     elif args.schema_type == "name":
-        map_file_path = f"{get_repo_config_relative_path()}/schema_map.json"
-        with open(map_file_path, "r", encoding="UTF-8") as map_file:
+        with open(get_schema_map_path(), "r", encoding="UTF-8") as map_file:
             schema_map = json.loads(map_file.read())
         data = schema_map[schema]
         schema_type = SchemaType(data["type"])
@@ -178,6 +177,10 @@ def run_command_main(args: Namespace) -> None:
         assert args.schema == schema.config.schema_name
     else:
         schema = AutoTransformSchema.from_data(json.loads(schema))
+
+    repo_override = get_config().repo_override
+    if repo_override is not None:
+        schema.repo = repo_override
 
     if args.filter:
         schema.filters.append(filter_factory.get_instance(json.loads(args.filter)))

--- a/src/python/autotransform/scripts/commands/settings.py
+++ b/src/python/autotransform/scripts/commands/settings.py
@@ -16,7 +16,12 @@ from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from typing import Dict, List
 
-from autotransform.config import CONFIG_FILE_NAME, get_cwd_config_dir, get_repo_config_dir
+from autotransform.config import (
+    CONFIG_FILE_NAME,
+    get_cwd_config_dir,
+    get_repo_config_dir,
+    get_schema_map_path,
+)
 from autotransform.config.config import Config
 from autotransform.schema.schema import AutoTransformSchema
 from autotransform.util.component import ComponentFactory, ComponentImport
@@ -329,7 +334,7 @@ def handle_schema_map(update: bool) -> None:
         update (bool): Whether to apply updates to the Schema Map.
     """
 
-    path = f"{get_repo_config_dir()}/schema_map.json"
+    path = get_schema_map_path()
     if Path(path).is_file():
         with open(path, "r", encoding="UTF-8") as schema_map_file:
             schema_map = json.loads(schema_map_file.read())

--- a/src/python/autotransform/scripts/migrations/p1_0_3.py
+++ b/src/python/autotransform/scripts/migrations/p1_0_3.py
@@ -15,7 +15,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 from typing import Any, Dict
 
-from autotransform.config import get_repo_config_relative_path
+from autotransform.config import get_repo_config_relative_path, get_schema_map_path
 from autotransform.schema.builder import FACTORY as schema_builder_factory
 from autotransform.schema.schema import AutoTransformSchema
 from autotransform.util.enums import SchemaType
@@ -62,7 +62,7 @@ def main() -> None:
     scheduler_data = json.loads(scheduler_json)
 
     # Get Schema Map if it exists
-    map_file_path = f"{get_repo_config_relative_path()}/schema_map.json"
+    map_file_path = get_schema_map_path()
     if Path(map_file_path).is_file():
         with open(map_file_path, "r", encoding="UTF-8") as map_file:
             schema_map = json.loads(map_file.read())

--- a/src/python/autotransform/util/scheduler.py
+++ b/src/python/autotransform/util/scheduler.py
@@ -17,9 +17,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Type
 
-from pydantic import validator
-
-from autotransform.config import get_repo_config_relative_path
+from autotransform.config import get_schema_map_path
 from autotransform.event.debug import DebugEvent
 from autotransform.event.handler import EventHandler
 from autotransform.event.schedulerun import ScheduleRunEvent
@@ -41,6 +39,7 @@ from autotransform.util.console import (
     input_ints,
 )
 from autotransform.util.enums import SchemaType
+from pydantic import validator
 
 
 class RepeatSetting(str, Enum):
@@ -289,8 +288,7 @@ class Scheduler(ComponentModel):
             )
             return
 
-        map_file_path = f"{get_repo_config_relative_path()}/schema_map.json"
-        with open(map_file_path, "r", encoding="UTF-8") as map_file:
+        with open(get_schema_map_path(), "r", encoding="UTF-8") as map_file:
             schema_map = json.loads(map_file.read())
 
         for scheduled_schema in self.schemas:


### PR DESCRIPTION
Response to https://github.com/nathro/AutoTransform/discussions/75

This does 2 main things:
 - Supports using a repo_override in Config to replace the repo of schemas that are being run
 - Allows use AUTO_TRANSFORM_SCHEMA_MAP_PATH environment variable to specify the location of the schema_map
 
 With this you can set the repo in your repo's config file, rather than each schema and use a centralized schema_map that contains your schemas. This allows you to have one job in one repo that can run a schema across many repos for organizations that don't use a monorepo.