### PR TITLE
Add SchemaMap class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
-## Release 1.0.8
+## Release 1.1.0
+
+### Migrations
+ - The schema map has been upgraded to use SchemaMap class, with all file targets now relative to the directory that contains the schema map.
 
 ### Features
  - Added an optional repo_override setting to Config that can be used to override the repo of supplied schemas

--- a/autotransform/schema_map.json
+++ b/autotransform/schema_map.json
@@ -1,6 +1,0 @@
-{
-    "Black Format": {
-        "type": "file",
-        "target": "autotransform/schemas/black_format.json"
-    }
-}

--- a/autotransform/schemas/schema_map.json
+++ b/autotransform/schemas/schema_map.json
@@ -1,0 +1,6 @@
+{
+    "Black Format": {
+        "type": "file",
+        "target": "black_format.json"
+    }
+}

--- a/docs/source/autotransform.util.request.rst
+++ b/docs/source/autotransform.util.request.rst
@@ -1,5 +1,5 @@
-autotransform.util.request module
-=================================
+RequestHandler (autotransform.util.request)
+===========================================
 
 .. automodule:: autotransform.util.request
    :members:

--- a/docs/source/autotransform.util.rst
+++ b/docs/source/autotransform.util.rst
@@ -16,4 +16,6 @@ Utilities
    autotransform.util.github
    autotransform.util.manager
    autotransform.util.package
+   autotransform.util.request
    autotransform.util.scheduler
+   autotransform.util.schema_map

--- a/docs/source/autotransform.util.schema_map.rst
+++ b/docs/source/autotransform.util.schema_map.rst
@@ -1,0 +1,7 @@
+SchemaMap (autotransform.util.request)
+======================================
+
+.. automodule:: autotransform.util.schema_map
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/examples/schema_map.json
+++ b/examples/schema_map.json
@@ -1,6 +1,0 @@
-{
-    "Black Format": {
-        "type": "file",
-        "target": "autotransform/schemas/black_format.json"
-    }
-}

--- a/examples/schemas/schema_map.json
+++ b/examples/schemas/schema_map.json
@@ -1,0 +1,6 @@
+{
+    "Black Format": {
+        "type": "file",
+        "target": "black_format.json"
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-heck# Requirements for core AutoTransform
+# Requirements for core AutoTransform
 GitPython>=3.1.27
 ghapi>=0.1.20
 typing-extensions>=4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Requirements for core AutoTransform
+heck# Requirements for core AutoTransform
 GitPython>=3.1.27
 ghapi>=0.1.20
 typing-extensions>=4.2.0
@@ -22,7 +22,7 @@ types-pytz>=2021.3.7
 types-requests>=2.28.11
 
 # Linting
-pylint >= 2.14.0
+pylint >= 2.15.6
 
 # Unit Tests
 pytest >= 7.1.2

--- a/src/python/autotransform/change/github.py
+++ b/src/python/autotransform/change/github.py
@@ -17,12 +17,11 @@ from typing import ClassVar, Dict, List, Tuple
 
 from autotransform.batcher.base import Batch
 from autotransform.change.base import Change, ChangeName, ChangeState, ReviewState, TestState
-from autotransform.config import get_config, get_schema_map_path
+from autotransform.config import get_config
 from autotransform.item.base import FACTORY as item_factory
-from autotransform.schema.builder import FACTORY as schema_builder_factory
 from autotransform.schema.schema import AutoTransformSchema
-from autotransform.util.enums import SchemaType
 from autotransform.util.github import GithubUtils, PullRequest
+from autotransform.util.schema_map import SchemaMap
 
 
 class GithubChange(Change):
@@ -56,15 +55,7 @@ class GithubChange(Change):
         """
 
         schema_name = self.get_schema_name()
-        with open(get_schema_map_path(), "r", encoding="UTF-8") as map_file:
-            schema_map = json.loads(map_file.read())
-        data = schema_map[schema_name]
-        schema_type = SchemaType(data["type"])
-        if schema_type == SchemaType.BUILDER:
-            schema = schema_builder_factory.get_instance({"name": data["target"]}).build()
-        else:
-            with open(data["target"], "r", encoding="utf-8") as schema_file:
-                schema = AutoTransformSchema.from_data(json.loads(schema_file.read()))
+        schema = SchemaMap.get().get_schema(schema_name)
         assert schema_name == schema.config.schema_name
         repo_override = get_config().repo_override
         if repo_override is not None:

--- a/src/python/autotransform/config/__init__.py
+++ b/src/python/autotransform/config/__init__.py
@@ -29,19 +29,6 @@ if TYPE_CHECKING:
 CONFIG_FILE_NAME = "config.json"
 
 
-def get_schema_map_path() -> str:
-    """Gets the path to the schema map.
-
-    Returns:
-        str: The path to the schema map.
-    """
-
-    return os.getenv(
-        "AUTO_TRANSFORM_SCHEMA_MAP_PATH",
-        f"{get_repo_config_relative_path()}/schema_map.json",
-    )
-
-
 def get_repo_config_relative_path() -> str:
     """Gets the relative path used for the repo config directory.
 

--- a/src/python/autotransform/scripts/commands/run.py
+++ b/src/python/autotransform/scripts/commands/run.py
@@ -14,7 +14,7 @@ import json
 import os
 from argparse import ArgumentParser, Namespace
 
-from autotransform.config import get_config, get_schema_map_path
+from autotransform.config import get_config
 from autotransform.event.debug import DebugEvent
 from autotransform.event.handler import EventHandler
 from autotransform.event.logginglevel import LoggingLevel
@@ -24,7 +24,7 @@ from autotransform.runner.base import Runner
 from autotransform.runner.local import LocalRunner
 from autotransform.schema.builder import FACTORY as schema_builder_factory
 from autotransform.schema.schema import AutoTransformSchema
-from autotransform.util.enums import SchemaType
+from autotransform.util.schema_map import SchemaMap
 
 
 def add_args(parser: ArgumentParser) -> None:
@@ -165,15 +165,7 @@ def run_command_main(args: Namespace) -> None:
         assert isinstance(schema, str)
         schema = AutoTransformSchema.from_data(json.loads(schema))
     elif args.schema_type == "name":
-        with open(get_schema_map_path(), "r", encoding="UTF-8") as map_file:
-            schema_map = json.loads(map_file.read())
-        data = schema_map[schema]
-        schema_type = SchemaType(data["type"])
-        if schema_type == SchemaType.BUILDER:
-            schema = schema_builder_factory.get_instance({"name": data["target"]}).build()
-        else:
-            with open(data["target"], "r") as schema_file:
-                schema = AutoTransformSchema.from_data(json.loads(schema_file.read()))
+        schema = SchemaMap.get().get_schema(args.schema)
         assert args.schema == schema.config.schema_name
     else:
         schema = AutoTransformSchema.from_data(json.loads(schema))

--- a/src/python/autotransform/util/schema_map.py
+++ b/src/python/autotransform/util/schema_map.py
@@ -1,0 +1,185 @@
+# AutoTransform
+# Large scale, component based code modification library
+#
+# Licensed under the MIT License <http://opensource.org/licenses/MIT>
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2022-present Nathan Rockenbach <http://github.com/nathro>
+
+# @black_format
+
+"""Provides utility methods for interacting with the Schema map."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Dict, Optional, Sequence, Tuple
+
+from autotransform.config import get_repo_config_relative_path
+from autotransform.schema.builder import FACTORY as schema_builder_factory
+from autotransform.schema.schema import AutoTransformSchema
+from autotransform.util.enums import SchemaType
+
+
+class SchemaMap:
+    """A map that can convert Schema names in to AutoTransformSchemas.
+
+    Attributes:
+        _data (Dict[str, Tuple[SchemaType, str]]): The data that backs the Schema map.
+        __instance (Optional[SchemaMap]): The singleton instance of the SchemaMap.
+    """
+
+    _data: Dict[str, Tuple[SchemaType, str]]
+
+    __instance: Optional[SchemaMap] = None
+
+    def __init__(self):
+        """A simple constructor for a singleton class"""
+
+        assert SchemaMap.__instance is None
+
+        map_file_path = SchemaMap.get_schema_map_path()
+        if Path(map_file_path).is_file():
+            with open(map_file_path, "r", encoding="UTF-8") as map_file:
+                schema_map = json.loads(map_file.read())
+        else:
+            schema_map = {}
+
+        self._data = {
+            name: (SchemaType(schema["type"]), schema["target"])
+            for name, schema in schema_map.items()
+        }
+
+    @staticmethod
+    def get() -> SchemaMap:
+        """Gets the singleton instance of the SchemaMap.
+
+        Returns:
+            SchemaMap: The singleton instance of the SchemaMap.
+        """
+
+        if SchemaMap.__instance is None:
+            SchemaMap.__instance = SchemaMap()
+
+        return SchemaMap.__instance
+
+    @staticmethod
+    def get_schema_directory() -> str:
+        """Gets the directory where schemas and the schema map are located.
+
+        Returns:
+            str: The directory where schemas and the schema map are located.
+        """
+
+        return os.getenv(
+            "AUTO_TRANSFORM_SCHEMA_DIRECTORY",
+            f"{get_repo_config_relative_path()}/schemas",
+        )
+
+    @staticmethod
+    def get_schema_map_path() -> str:
+        """Gets the path to the schema map.
+
+        Returns:
+            str: The path to the schema map.
+        """
+
+        return f"{SchemaMap.get_schema_directory()}/schema_map.json"
+
+    @staticmethod
+    def get_schema_path(file_name: str) -> str:
+        """Gets the path to a given schema
+
+        Args:
+            file_name (str): The name of the file for a schema.
+
+        Returns:
+            str: The path where a schema is located.
+        """
+
+        return f"{SchemaMap.get_schema_directory()}/{file_name}"
+
+    def get_schema(self, schema_name: str) -> AutoTransformSchema:
+        """Get an AutoTransformSchema from the map.
+
+        Args:
+            schema_name (str): The name of the schema to get.
+
+        Returns:
+            AutoTransformSchema: The AutoTransformSchema with the supplied name.
+        """
+
+        schema_type, target = self._data[schema_name]
+
+        if schema_type == SchemaType.BUILDER:
+            return schema_builder_factory.get_instance({"name": target}).build()
+
+        with open(SchemaMap.get_schema_path(target), "r", encoding="UTF-8") as schema_file:
+            return AutoTransformSchema.from_data(json.loads(schema_file.read()))
+
+    def add_schema(self, schema_name: str, schema_type: SchemaType, target: str) -> None:
+        """Adds the specified Schema to the map.
+
+        Args:
+            schema_name (str): The name of the Schema to add.
+            schema_type (SchemaType): The type of the Schema.
+            target (str): The target for the Schema.
+        """
+
+        self._data[schema_name] = (schema_type, target)
+
+    def remove_schema(self, schema_name: str) -> None:
+        """Removes the specified Schema from the map.
+
+        Args:
+            schema_name (str): The name of the Schema to remove.
+        """
+
+        del self._data[schema_name]
+
+    def write(self) -> None:
+        """Writes the SchemaMap to a file as JSON."""
+
+        schema_map_data = {
+            name: {"type": schema[0], "target": schema[1]} for name, schema in self._data.items()
+        }
+
+        file_path = SchemaMap.get_schema_map_path()
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        with open(file_path, "w+", encoding="UTF-8") as schema_map_file:
+            schema_map_file.write(json.dumps(schema_map_data, indent=4))
+            schema_map_file.flush()
+
+    def items(self) -> Sequence[Tuple[str, Tuple[SchemaType, str]]]:
+        """Gets the items in the SchemaMap.
+
+        Returns:
+            Tuple[str, Tuple[SchemaType, str]]: The items from the SchemaMap.
+        """
+
+        return list(self._data.items())
+
+    def __contains__(self, schema_name: str) -> bool:
+        """Override the contains method for the map.
+
+        Args:
+            schema_name (str): The name to check for in the SchemaMap.
+
+        Returns:
+            bool: Whether a Schema with the given name is in the map.
+        """
+
+        return schema_name in self._data
+
+    def __getitem__(self, schema_name: str) -> AutoTransformSchema:
+        """Override the subscript operator.
+
+        Args:
+            schema_name (str): The name of the Schema to get.
+
+        Returns:
+            AutoTransformSchema: The Schema with the specified name.
+        """
+
+        return self.get_schema(schema_name)

--- a/tests/migrations/test_1_0_3_migration.py
+++ b/tests/migrations/test_1_0_3_migration.py
@@ -13,6 +13,7 @@ import json
 import pathlib
 
 from autotransform.scripts.migrations.p1_0_3 import update_scheduler_data
+from autotransform.util.schema_map import SchemaMap
 
 
 def test_migration():
@@ -21,10 +22,9 @@ def test_migration():
     parent_dir = str(pathlib.Path(__file__).parent.resolve()).replace("\\", "/")
     with open(f"{parent_dir}/data/scheduler.input.json", "r", encoding="UTF-8") as input_scheduler:
         scheduler_data = json.loads(input_scheduler.read())
-    with open(
-        f"{parent_dir}/data/schema_map.input.json", "r", encoding="UTF-8"
-    ) as input_schema_map:
-        schema_map = json.loads(input_schema_map.read())
+
+    SchemaMap.get_schema_map_path = lambda: f"{parent_dir}/data/schema_map.input.json"
+    schema_map = SchemaMap.get()
 
     update_scheduler_data(scheduler_data, schema_map)
 
@@ -32,10 +32,10 @@ def test_migration():
         f"{parent_dir}/data/scheduler.output.json", "r", encoding="UTF-8"
     ) as output_scheduler:
         expected_scheduler_data = json.loads(output_scheduler.read())
-    with open(
-        f"{parent_dir}/data/schema_map.output.json", "r", encoding="UTF-8"
-    ) as output_schema_map:
-        expected_output_schema_map = json.loads(output_schema_map.read())
+
+    SchemaMap.__instance = None  # pylint: disable=protected-access
+    SchemaMap.get_schema_map_path = lambda: f"{parent_dir}/data/schema_map.output.json"
+    expected_output_schema_map = SchemaMap.get()
 
     assert scheduler_data == expected_scheduler_data
-    assert schema_map == expected_output_schema_map
+    assert schema_map._data == expected_output_schema_map._data  # pylint: disable=protected-access


### PR DESCRIPTION
Adds a SchemaMap class to handle the map logic, while also updating the target paths to be relative to the location of the schema map. This also switches us to 1.1.0 because the SchemaMap includes a non-compatible change.