### PR TITLE
Add support for controlling checkout repo and ref for GithubRunner

### DIFF
--- a/.github/workflows/autotransform.run.yml
+++ b/.github/workflows/autotransform.run.yml
@@ -22,6 +22,16 @@ on:
         description: "A filter to add to the schema"
         type: string
         required: false
+      target_repo_name:
+        description: "The name of the repo to checkout"
+        type: string
+        required: false
+        default: ""
+      target_repo_name:
+        description: "The ref of the repo to checkout"
+        type: string
+        required: false
+        default: ""
 
 jobs:
   run-autotransform:
@@ -31,6 +41,8 @@ jobs:
     - uses: actions/checkout@v3
       with:
         token: ${{ secrets.AUTO_TRANSFORM_BOT_GITHUB_TOKEN }}
+        repository: ${{ github.event.inputs.target_repo_name}}
+        ref: ${{ github.event.inputs.target_repo_ref}}
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/autotransform.run.yml
+++ b/.github/workflows/autotransform.run.yml
@@ -26,12 +26,12 @@ on:
         description: "The name of the repo to checkout"
         type: string
         required: false
-        default: ""
+        default: ''
       target_repo_name:
         description: "The ref of the repo to checkout"
         type: string
         required: false
-        default: ""
+        default: ''
 
 jobs:
   run-autotransform:

--- a/.github/workflows/autotransform.run.yml
+++ b/.github/workflows/autotransform.run.yml
@@ -26,12 +26,10 @@ on:
         description: "The name of the repo to checkout"
         type: string
         required: false
-        default: ${{ GITHUB_ACTION_REPOSITORY }}
       target_repo_ref:
         description: "The ref of the repo to checkout"
         type: string
         required: false
-        default: ${{ GITHUB_REF }}
 
 jobs:
   run-autotransform:

--- a/.github/workflows/autotransform.run.yml
+++ b/.github/workflows/autotransform.run.yml
@@ -27,7 +27,7 @@ on:
         type: string
         required: false
         default: ${{ GITHUB_ACTION_REPOSITORY }}
-      target_repo_name:
+      target_repo_ref:
         description: "The ref of the repo to checkout"
         type: string
         required: false

--- a/.github/workflows/autotransform.run.yml
+++ b/.github/workflows/autotransform.run.yml
@@ -25,12 +25,10 @@ on:
       target_repo_name:
         description: "The name of the repo to checkout"
         type: string
-        required: false
         default: ''
       target_repo_name:
         description: "The ref of the repo to checkout"
         type: string
-        required: false
         default: ''
 
 jobs:

--- a/.github/workflows/autotransform.run.yml
+++ b/.github/workflows/autotransform.run.yml
@@ -25,11 +25,13 @@ on:
       target_repo_name:
         description: "The name of the repo to checkout"
         type: string
-        default: ''
+        required: false
+        default: ${{ GITHUB_ACTION_REPOSITORY }}
       target_repo_name:
         description: "The ref of the repo to checkout"
         type: string
-        default: ''
+        required: false
+        default: ${{ GITHUB_REF }}
 
 jobs:
   run-autotransform:

--- a/.github/workflows/autotransform.update.yml
+++ b/.github/workflows/autotransform.update.yml
@@ -17,12 +17,10 @@ on:
       target_repo_name:
         description: "The name of the repo to checkout"
         type: string
-        required: false
         default: ''
       target_repo_name:
         description: "The ref of the repo to checkout"
         type: string
-        required: false
         default: ''
 
 jobs:

--- a/.github/workflows/autotransform.update.yml
+++ b/.github/workflows/autotransform.update.yml
@@ -18,12 +18,10 @@ on:
         description: "The name of the repo to checkout"
         type: string
         required: false
-        default: ${{ GITHUB_ACTION_REPOSITORY }}
       target_repo_ref:
         description: "The ref of the repo to checkout"
         type: string
         required: false
-        default: ${{ GITHUB_REF }}
 
 jobs:
   update-autotransform:

--- a/.github/workflows/autotransform.update.yml
+++ b/.github/workflows/autotransform.update.yml
@@ -17,11 +17,13 @@ on:
       target_repo_name:
         description: "The name of the repo to checkout"
         type: string
-        default: ''
+        required: false
+        default: ${{ GITHUB_ACTION_REPOSITORY }}
       target_repo_name:
         description: "The ref of the repo to checkout"
         type: string
-        default: ''
+        required: false
+        default: ${{ GITHUB_REF }}
 
 jobs:
   update-autotransform:

--- a/.github/workflows/autotransform.update.yml
+++ b/.github/workflows/autotransform.update.yml
@@ -14,6 +14,16 @@ on:
         description: "A JSON encoded Change to update"
         required: true
         type: string
+      target_repo_name:
+        description: "The name of the repo to checkout"
+        type: string
+        required: false
+        default: ""
+      target_repo_name:
+        description: "The ref of the repo to checkout"
+        type: string
+        required: false
+        default: ""
 
 jobs:
   update-autotransform:
@@ -23,6 +33,8 @@ jobs:
     - uses: actions/checkout@v3
       with:
         token: ${{ secrets.AUTO_TRANSFORM_BOT_GITHUB_TOKEN }}
+        repository: ${{ github.event.inputs.target_repo_name}}
+        ref: ${{ github.event.inputs.target_repo_ref}}
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/autotransform.update.yml
+++ b/.github/workflows/autotransform.update.yml
@@ -19,7 +19,7 @@ on:
         type: string
         required: false
         default: ${{ GITHUB_ACTION_REPOSITORY }}
-      target_repo_name:
+      target_repo_ref:
         description: "The ref of the repo to checkout"
         type: string
         required: false

--- a/.github/workflows/autotransform.update.yml
+++ b/.github/workflows/autotransform.update.yml
@@ -18,12 +18,12 @@ on:
         description: "The name of the repo to checkout"
         type: string
         required: false
-        default: ""
+        default: ''
       target_repo_name:
         description: "The ref of the repo to checkout"
         type: string
         required: false
-        default: ""
+        default: ''
 
 jobs:
   update-autotransform:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
  - Added an optional repo_override setting to Config that can be used to override the repo of supplied schemas
  - Added AUTO_TRANSFORM_SCHEMA_MAP_PATH environment variable support to override default schema_map path
  - Script components now can take a replacement dictionary as the environment variable AUTO_TRANSFORM_SCRIPT_REPLACEMENTS
+ - Added target_repo_name and target_repo_ref to GithubRunner so that workflow can control checkout with inputs, makes having a single repo that acts on all of your repos a bit better
 
 ### New Components
  - AggregateFilter a filter that aggregates other filters

--- a/examples/workflows/autotransform.run.yml
+++ b/examples/workflows/autotransform.run.yml
@@ -19,12 +19,12 @@ on:
         description: "The name of the repo to checkout"
         type: string
         required: false
-        default: ""
+        default: ''
       target_repo_name:
         description: "The ref of the repo to checkout"
         type: string
         required: false
-        default: ""
+        default: ''
 
 jobs:
   run-autotransform:

--- a/examples/workflows/autotransform.run.yml
+++ b/examples/workflows/autotransform.run.yml
@@ -18,11 +18,13 @@ on:
       target_repo_name:
         description: "The name of the repo to checkout"
         type: string
-        default: ''
+        required: false
+        default: ${{ GITHUB_ACTION_REPOSITORY }}
       target_repo_name:
         description: "The ref of the repo to checkout"
         type: string
-        default: ''
+        required: false
+        default: ${{ GITHUB_REF }}
 
 jobs:
   run-autotransform:

--- a/examples/workflows/autotransform.run.yml
+++ b/examples/workflows/autotransform.run.yml
@@ -20,7 +20,7 @@ on:
         type: string
         required: false
         default: ${{ GITHUB_ACTION_REPOSITORY }}
-      target_repo_name:
+      target_repo_ref:
         description: "The ref of the repo to checkout"
         type: string
         required: false

--- a/examples/workflows/autotransform.run.yml
+++ b/examples/workflows/autotransform.run.yml
@@ -15,6 +15,16 @@ on:
         description: "A filter to add to the schema"
         type: string
         required: false
+      target_repo_name:
+        description: "The name of the repo to checkout"
+        type: string
+        required: false
+        default: ""
+      target_repo_name:
+        description: "The ref of the repo to checkout"
+        type: string
+        required: false
+        default: ""
 
 jobs:
   run-autotransform:
@@ -24,6 +34,8 @@ jobs:
     - uses: actions/checkout@v3
       with:
         token: ${{ secrets.AUTO_TRANSFORM_BOT_GITHUB_TOKEN }}
+        repository: ${{ github.event.inputs.target_repo_name}}
+        ref: ${{ github.event.inputs.target_repo_ref}}
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:

--- a/examples/workflows/autotransform.run.yml
+++ b/examples/workflows/autotransform.run.yml
@@ -19,12 +19,10 @@ on:
         description: "The name of the repo to checkout"
         type: string
         required: false
-        default: ${{ GITHUB_ACTION_REPOSITORY }}
       target_repo_ref:
         description: "The ref of the repo to checkout"
         type: string
         required: false
-        default: ${{ GITHUB_REF }}
 
 jobs:
   run-autotransform:

--- a/examples/workflows/autotransform.run.yml
+++ b/examples/workflows/autotransform.run.yml
@@ -18,12 +18,10 @@ on:
       target_repo_name:
         description: "The name of the repo to checkout"
         type: string
-        required: false
         default: ''
       target_repo_name:
         description: "The ref of the repo to checkout"
         type: string
-        required: false
         default: ''
 
 jobs:

--- a/examples/workflows/autotransform.update.yml
+++ b/examples/workflows/autotransform.update.yml
@@ -10,11 +10,13 @@ on:
       target_repo_name:
         description: "The name of the repo to checkout"
         type: string
-        default: ''
+        required: false
+        default: ${{ GITHUB_ACTION_REPOSITORY }}
       target_repo_name:
         description: "The ref of the repo to checkout"
         type: string
-        default: ''
+        required: false
+        default: ${{ GITHUB_REF }}
 
 permissions:
   contents: write

--- a/examples/workflows/autotransform.update.yml
+++ b/examples/workflows/autotransform.update.yml
@@ -12,7 +12,7 @@ on:
         type: string
         required: false
         default: ${{ GITHUB_ACTION_REPOSITORY }}
-      target_repo_name:
+      target_repo_ref:
         description: "The ref of the repo to checkout"
         type: string
         required: false

--- a/examples/workflows/autotransform.update.yml
+++ b/examples/workflows/autotransform.update.yml
@@ -7,6 +7,16 @@ on:
         description: "A JSON encoded Change to update"
         required: true
         type: string
+      target_repo_name:
+        description: "The name of the repo to checkout"
+        type: string
+        required: false
+        default: ""
+      target_repo_name:
+        description: "The ref of the repo to checkout"
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: write
@@ -19,6 +29,8 @@ jobs:
     - uses: actions/checkout@v3
       with:
         token: ${{ secrets.AUTO_TRANSFORM_BOT_GITHUB_TOKEN }}
+        repository: ${{ github.event.inputs.target_repo_name}}
+        ref: ${{ github.event.inputs.target_repo_ref}}
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:

--- a/examples/workflows/autotransform.update.yml
+++ b/examples/workflows/autotransform.update.yml
@@ -10,13 +10,11 @@ on:
       target_repo_name:
         description: "The name of the repo to checkout"
         type: string
-        required: false
-        default: ""
+        default: ''
       target_repo_name:
         description: "The ref of the repo to checkout"
         type: string
-        required: false
-        default: ""
+        default: ''
 
 permissions:
   contents: write

--- a/examples/workflows/autotransform.update.yml
+++ b/examples/workflows/autotransform.update.yml
@@ -11,12 +11,10 @@ on:
         description: "The name of the repo to checkout"
         type: string
         required: false
-        default: ${{ GITHUB_ACTION_REPOSITORY }}
       target_repo_ref:
         description: "The ref of the repo to checkout"
         type: string
         required: false
-        default: ${{ GITHUB_REF }}
 
 permissions:
   contents: write

--- a/src/python/autotransform/runner/github.py
+++ b/src/python/autotransform/runner/github.py
@@ -37,6 +37,12 @@ class GithubRunner(Runner):
             If not provided, the repo of the Schema will be used. Defaults to None.
         repo_ref (optional, Optional[str]): The ref of the Github repo to trigger actions from.
             If not provided, the base branch of the Schema's repo will be used. Defaults to None.
+        target_repo_name (optional, Optional[str]): The name of the Github repo to checkout.
+            If not provided, the workflow is expected to define the repo on it's own.
+            Defaults to None.
+        target_repo_ref (optional, Optional[str]): The ref of the Github repo to checkout.
+            If not provided, the workflow is expected to define the repo on it's own.
+            Defaults to None.
         name (ClassVar[RunnerName]): The name of the component.
     """
 
@@ -45,6 +51,8 @@ class GithubRunner(Runner):
 
     repo_name: Optional[str] = None
     repo_ref: Optional[str] = None
+    target_repo_name: Optional[str] = None
+    target_repo_ref: Optional[str] = None
 
     name: ClassVar[RunnerName] = RunnerName.GITHUB
 
@@ -147,6 +155,12 @@ class GithubRunner(Runner):
                 repo, GithubRepo
             ), "GithubRunner can only run using schemas that have Github repos"
             repo_ref = repo.base_branch
+
+        # Allow controlling the target repo with the Runner
+        if self.target_repo_name is not None:
+            inputs["target_repo_name"] = self.target_repo_name
+        if self.target_repo_ref is not None:
+            inputs["target_repo_ref"] = self.target_repo_ref
 
         # Dispatch a Workflow run
         workflow_url = GithubUtils.get(repo_name).create_workflow_dispatch(


### PR DESCRIPTION
This will make having a central repo that you use for every repo simpler since it won't need a command for each repo.