### PR TITLE
Fix schema name for GithubChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### Bugs
  - Fixes reviewers being requested for CodeownersBatcher when the metadata doesn't have the field present
  - Fixes search for outstanding PRs to properly limit by repo
+ - Fix getting the name of the schema off a GithubChange
 
 ## Release 1.0.7
 

--- a/src/python/autotransform/change/github.py
+++ b/src/python/autotransform/change/github.py
@@ -71,7 +71,7 @@ class GithubChange(Change):
             str: The name of the Schema.
         """
 
-        return self._pull_request.branch.split("/")[1].replace("_", " ")
+        return self._automation_data[0].config.schema_name
 
     def get_state(self) -> ChangeState:
         """Gets the current state of the Change.


### PR DESCRIPTION
This was broken when the change that removed / from branch names was added.