### PR TITLE
Support multiple gists for GithubChanges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugs
 - Fix ScriptCommand to return when run_on_changes is set to true for batch runs and no changes are present.
+- Splits Gists apart to support batches with large numbers of items that can't be read from a single Gist in API requests
 
 ## Release 1.1.0
 


### PR DESCRIPTION
Gists returned from the API are limited to 1 MB of data, so this change makes it so that we can use multiple gists to represent large batches.