### PR TITLE
Update GitPython version because of security issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Requirements for core AutoTransform
-GitPython==3.1.30
+GitPython==3.1.32
 ghapi==1.0.3
 typing-extensions==4.4.0
 colorama==0.4.6

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setuptools.setup(
     package_dir={"": "src/python"},
     packages=setuptools.find_packages("src/python"),
     install_requires=[
-        "GitPython==3.1.30",
+        "GitPython==3.1.32",
         "ghapi==1.0.3",
         "typing-extensions==4.4.0",
         "colorama==0.4.6",


### PR DESCRIPTION
What it says on the tin, dependabot flagged an issue with the older version of GitPython.