### PR TITLE
Fix GithubRunner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix ScriptCommand to return when run_on_changes is set to true for batch runs and no changes are present.
 - Splits Gists apart to support batches with large numbers of items that can't be read from a single Gist in API requests
 - Fix ScriptTransformer when run with no items
+- Fix GithubRunner when using repo_override rather than schema repos
 
 ## Release 1.1.0
 

--- a/src/python/autotransform/runner/github.py
+++ b/src/python/autotransform/runner/github.py
@@ -15,6 +15,7 @@ import json
 from typing import Any, ClassVar, Dict, Optional
 
 from autotransform.change.base import Change
+from autotransform.config import get_config
 from autotransform.event.debug import DebugEvent
 from autotransform.event.handler import EventHandler
 from autotransform.event.remoterun import RemoteRunEvent
@@ -142,7 +143,7 @@ class GithubRunner(Runner):
         if self.repo_name is not None:
             repo_name = self.repo_name
         else:
-            repo = schema.repo
+            repo = get_config().repo_override or schema.repo
             assert isinstance(
                 repo, GithubRepo
             ), "GithubRunner can only run using schemas that have Github repos"


### PR DESCRIPTION
Fixes the GithubRunner to understand that the repo can be pulled from the repo_override rather than the schema for some cases.