### PR TITLE
Add support for python3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def generate_datafiles() -> List[Tuple[str, List[str]]]:
 
 setuptools.setup(
     name="AutoTransform",
-    version="1.1.1a13",
+    version="1.1.1a14",
     author="Nathan Rockenbach",
     author_email="nathro.software@gmail.com",
     description="A component based framework for designing automated code modification",
@@ -79,7 +79,7 @@ setuptools.setup(
         "codeowners==0.6.0",
         "openai==0.27.8",
     ],
-    python_requires=">=3.10",
+    python_requires=">=3.9",
     data_files=generate_datafiles(),
     entry_points={
         "console_scripts": [

--- a/src/python/autotransform/step/condition/base.py
+++ b/src/python/autotransform/step/condition/base.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, ClassVar, Dict, Generic, List, Optional, Set, Type, TypeVar
+from typing import Any, ClassVar, Dict, Generic, List, Optional, Set, Type, TypeVar, Union
 
 from autotransform.change.base import Change
 from autotransform.step.condition.comparison import ComparisonType, compare
@@ -74,7 +74,7 @@ class ComparisonCondition(Generic[T], Condition):
     """
 
     comparison: ComparisonType
-    value: T | List[T]
+    value: Union[T, List[T]]
 
     name: ClassVar[ConditionName]
 

--- a/src/python/autotransform/step/condition/request.py
+++ b/src/python/autotransform/step/condition/request.py
@@ -11,7 +11,7 @@
 
 import os
 from functools import cached_property
-from typing import Any, ClassVar, List, Mapping, Optional, TypeVar
+from typing import Any, ClassVar, List, Mapping, Optional, TypeVar, Union
 
 from autotransform.change.base import Change
 from autotransform.step.condition.base import ComparisonCondition, ConditionName
@@ -45,7 +45,7 @@ class RequestStrCondition(ComparisonCondition[str]):
 
     comparison: ComparisonType
     url: str
-    value: str | List[str]
+    value: Union[str, List[str]]
 
     data: Mapping[str, Any] = Field(default_factory=dict)
     headers: Mapping[str, Any] = Field(default_factory=dict)

--- a/src/python/autotransform/validator/base.py
+++ b/src/python/autotransform/validator/base.py
@@ -15,9 +15,16 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, ClassVar, Dict, Mapping, Optional
+import platform
 
 from autotransform.batcher.base import Batch
 from autotransform.util.component import ComponentFactory, ComponentImport, NamedComponent
+
+if platform.sys.version_info.minor < 10:
+  kwargs = {}
+else:
+  # kw_only is a py3.10 only feature
+  kwargs = {"kw_only": True}
 
 
 class ValidationResultLevel(str, Enum):
@@ -60,8 +67,7 @@ class ValidationResultLevel(str, Enum):
     def __ge__(self, other: object) -> bool:
         return self.compare(str(other.value) if isinstance(other, Enum) else str(other)) >= 0
 
-
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, **kwargs)
 class ValidationResult:
     """Represents the result of an attempt at validation.
 
@@ -77,7 +83,7 @@ class ValidationResult:
     message: Optional[str] = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True, **kwargs)
 class ValidationError(Exception):
     """An error raised by validation failing on a run.
 


### PR DESCRIPTION
## Why?
Python3.9 will be EOL'ed in October 2025, which means an additional 18 months of support.

https://endoflife.date/python

I'd like to start using autotransform in a repo that is currently using python3.9 and I'd like to avoid a separate virtual environment, requirements file, etc.

## What?
- Modify setup.py to allow python3.9
- Bump version to 1.1.1a14
- Update references in `validator/base.py` to handle the `@dataclass` decorator not supporting
the `kw_only` arg in python3.9.
- Update references to union types using the `|` syntax to use `Union[]` instead.